### PR TITLE
Cleanup of the issue-creation and issue-checking code and workflows.

### DIFF
--- a/.github/workflows/issue_checker.yml
+++ b/.github/workflows/issue_checker.yml
@@ -1,4 +1,4 @@
-name: Check Title Against OBIS
+name: Check issues against OBIS
 
 on:
   schedule:
@@ -20,18 +20,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      
-      - name: Install dependencies
+
+      - name: Install package
         run: |
-          pip install requests PyGithub
-      
-      - name: Run dataset checker
+          python -m pip install -e .
+
+      - name: Run issue checker
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
-        run: python check_title_against_obis.py
+        run: python -m obisnd.issue_checker

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ In November 2021, GBIF released **IPT version 2.5.2**, which introduced the abil
 
 To close this gap, the OBIS Secretariat developed a Python package that uses the GBIF API to detect "missing" datasets and create GitHub issues for nodes to review.
 
-## Producer
+## Issue creator
 
-The producer is the core of this repository: a scheduled job that scans the GBIF OBIS network for datasets not yet in OBIS and files a GitHub issue for each one.
+The issue creator is the core of this repository: a scheduled job that scans the GBIF OBIS network for datasets not yet in OBIS and files a GitHub issue for each one.
 
 **What it does:**
 - Pulls every dataset GBIF lists under the OBIS network

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To close this gap, the OBIS Secretariat developed a Python package that uses the
 The issue creator is the core of this repository: a scheduled job that scans the GBIF OBIS network for datasets not yet in OBIS and files a GitHub issue for each one.
 
 **What it does:**
-- Pulls every dataset GBIF lists under the OBIS network
+- Pulls metadata for every dataset GBIF lists under the OBIS network
 - Compares each one against OBIS (by source URL, archive URL, and the OBIS blacklist)
 - Skips datasets that are already in OBIS, orphaned at GBIF, or already have an open issue
 - For everything that's left, opens a new issue containing the title, GBIF URL, DOI, and DwC-A archive endpoint
@@ -41,11 +41,6 @@ The issue creator is the core of this repository: a scheduled job that scans the
   - Endorse appropriate datasets.
   - Coordinate with publishers to resolve any quality concerns.
 - Once endorsed, the OBIS Secretariat harvests the dataset directly from the source IPT and lists it on the endorsing node's OBIS page.
-
-This process ensures that:
-- The **same, best-quality "master copy"** of each dataset flows to both GBIF and OBIS.
-- **Duplicate records are avoided**.
-- OBIS is **recognized within GBIF as the global marine biodiversity network**.
 
 All OBIS node managers and data managers are encouraged to **watch this repository** and stay engaged in reviewing and endorsing new datasets.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 ## Overview
 
-<a href="https://www.youtube.com/watch?v=4U1mjvCpC6s">
-  <img src="https://img.youtube.com/vi/4U1mjvCpC6s/hqdefault.jpg" width="400" alt="Watch the overview video"><br>
-  ▶ Watch the overview video
-</a>
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=4U1mjvCpC6s">
+    <img src="https://img.youtube.com/vi/4U1mjvCpC6s/hqdefault.jpg" width="400" alt="Watch the overview video"><br>
+    ▶ Watch the overview video
+  </a>
+</p>
 
 ## What is this repository?
 
@@ -18,6 +20,18 @@ To address this, the OBIS Secretariat created this repository to track marine da
 In November 2021, GBIF released **IPT version 2.5.2**, which introduced the ability for publishers to link datasets to networks such as OBIS. Datasets marked with the OBIS network tag automatically appear on the [OBIS network page in GBIF](https://www.gbif.org/network/2b7c7b4f-4d4f-40d3-94de-c28b6fa054a6). However, not all of these datasets were flowing into OBIS.
 
 To close this gap, the OBIS Secretariat developed a Python package that uses the GBIF API to detect "missing" datasets and create GitHub issues for nodes to review.
+
+## Producer
+
+The producer is the core of this repository: a scheduled job that scans the GBIF OBIS network for datasets not yet in OBIS and files a GitHub issue for each one.
+
+**What it does:**
+- Pulls every dataset GBIF lists under the OBIS network
+- Compares each one against OBIS (by source URL, archive URL, and the OBIS blacklist)
+- Skips datasets that are already in OBIS, orphaned at GBIF, or already have an open issue
+- For everything that's left, opens a new issue containing the title, GBIF URL, DOI, and DwC-A archive endpoint
+
+**Schedule:** Runs automatically every 6 hours via GitHub Actions.
 
 ## Workflow
 
@@ -58,47 +72,21 @@ To view all open issues **not currently assigned to a node**, use [this filter](
 
 ## Issue checker
 
-A GitHub Action that runs weekly to check whether datasets in open issues already exist in OBIS.
+A separate scheduled job that revisits open issues to catch datasets that have been published to OBIS since the issue was filed.
 
 **What it does:**
-- Scans open issues for dataset titles and URLs
-- Queries the OBIS API for an exact title match
+- Walks every open issue
+- Searches OBIS for an exact title match
 - Compares source URLs between the issue and OBIS
 - If the issue's URLs don't match OBIS but the issue references a GBIF dataset, cross-checks the GBIF identifiers (DOI, DwC-A endpoint) against the OBIS source URLs
 
 **Results:**
-- **Exact match (title + URL)**: Adds "In OBIS" label, comments with OBIS link, and closes the issue
-- **Title match only**: Adds a warning comment showing URL mismatch (issue stays open)
+- **Exact match (title + URL)**: Adds "In OBIS" label, comments with the OBIS link, and closes the issue
+- **Title match only**: Adds a warning comment showing the URL mismatch (issue stays open)
 - **No match**: No action taken
 
-**Schedule:** Runs automatically every Sunday at midnight UTC, or can be triggered manually via the Actions tab.
+**Schedule:** Runs automatically every Sunday at midnight UTC.
 
-## Running the tools
+## How it runs
 
-This repository ships as a Python package with two entry points: the **producer**, which creates new issues for GBIF datasets that aren't in OBIS, and the **issue checker**, which closes issues for datasets that have since been published to OBIS.
-
-### Setup
-
-Create a `.env` file with a `GITHUB_TOKEN` environment variable (a GitHub personal access token with `repo` scope). Install the package:
-
-```bash
-pip install -e .
-```
-
-### Producer
-
-Creates new issues for GBIF-tagged OBIS-network datasets that aren't yet in OBIS:
-
-```bash
-python -m obisnd
-```
-
-### Issue checker
-
-Walks open issues and closes any that are now in OBIS. Supports `--dry-run` to log intended actions without making changes:
-
-```bash
-python -m obisnd.issue_checker --dry-run
-```
-
-Other options: `--issue-range START END`, `--issues N N N`, `--repo owner/name`. When run as a GitHub Action, the token is provided automatically.
+Both jobs run as GitHub Actions on a schedule; no local setup is needed for normal operation. The workflows live in [`.github/workflows/`](.github/workflows/). Either can also be triggered manually from the Actions tab.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This repository ships as a Python package with two entry points: the **producer*
 
 ### Setup
 
-Create a `.env` file with environment variables `GITHUB_USER` and `GITHUB_ACCESS_TOKEN`. Install the package:
+Create a `.env` file with a `GITHUB_TOKEN` environment variable (a GitHub personal access token with `repo` scope). Install the package:
 
 ```bash
 pip install -e .
@@ -98,4 +98,4 @@ Walks open issues and closes any that are now in OBIS. Supports `--dry-run` to l
 python -m obisnd.issue_checker --dry-run
 ```
 
-Other options: `--issue-range START END`, `--issues N N N`, `--repo owner/name`. The issue checker uses the `GITHUB_TOKEN` environment variable (separate from the producer's `GITHUB_ACCESS_TOKEN`). When run as a GitHub Action, both are provided automatically.
+Other options: `--issue-range START END`, `--issues N N N`, `--repo owner/name`. When run as a GitHub Action, the token is provided automatically.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-[![Watch the overview video](https://img.youtube.com/vi/4U1mjvCpC6s/maxresdefault.jpg)](https://www.youtube.com/watch?v=4U1mjvCpC6s)
+<a href="https://www.youtube.com/watch?v=4U1mjvCpC6s">
+  <img src="https://img.youtube.com/vi/4U1mjvCpC6s/hqdefault.jpg" width="400" alt="Watch the overview video"><br>
+  ▶ Watch the overview video
+</a>
 
 ## What is this repository?
 

--- a/README.md
+++ b/README.md
@@ -1,63 +1,67 @@
 # obis-network-datasets
 
-## What is this repository?  
+## Overview
 
-As reported at the 10th meeting of the IODE Steering Group for OBIS (SG-OBIS-10) [Document link, see Section 3.1, pgs 39–40](https://oceanexpert.org/document/30481), OBIS and GBIF both host large volumes of marine biodiversity data. However, this overlap can lead to duplication and confusion for users.  
+[![Watch the overview video](https://img.youtube.com/vi/4U1mjvCpC6s/maxresdefault.jpg)](https://www.youtube.com/watch?v=4U1mjvCpC6s)
 
-To address this, the OBIS Secretariat created this repository to track marine datasets that are **tagged in GBIF as part of the OBIS network** but are **not yet available in OBIS**. Each dataset is represented as a GitHub issue so that OBIS nodes can review and endorse them.  
+## What is this repository?
 
-## History  
+As reported at the 10th meeting of the IODE Steering Group for OBIS (SG-OBIS-10) [Document link, see Section 3.1, pgs 39–40](https://oceanexpert.org/document/30481), OBIS and GBIF both host large volumes of marine biodiversity data. However, this overlap can lead to duplication and confusion for users.
 
-In November 2021, GBIF released **IPT version 2.5.2**, which introduced the ability for publishers to link datasets to networks such as OBIS. Datasets marked with the OBIS network tag automatically appear on the [OBIS network page in GBIF](https://www.gbif.org/network/2b7c7b4f-4d4f-40d3-94de-c28b6fa054a6). However, not all of these datasets were flowing into OBIS.  
+To address this, the OBIS Secretariat created this repository to track marine datasets that are **tagged in GBIF as part of the OBIS network** but are **not yet available in OBIS**. Each dataset is represented as a GitHub issue so that OBIS nodes can review and endorse them.
 
-To close this gap, the OBIS Secretariat developed a Python package that uses the GBIF API to detect “missing” datasets and create GitHub issues for nodes to review.  
+## History
 
-## Workflow  
+In November 2021, GBIF released **IPT version 2.5.2**, which introduced the ability for publishers to link datasets to networks such as OBIS. Datasets marked with the OBIS network tag automatically appear on the [OBIS network page in GBIF](https://www.gbif.org/network/2b7c7b4f-4d4f-40d3-94de-c28b6fa054a6). However, not all of these datasets were flowing into OBIS.
 
-- Each dataset appears here as an issue.  
-- OBIS nodes are expected to:  
-  - Monitor these issues.  
-  - Endorse appropriate datasets.  
-  - Coordinate with publishers to resolve any quality concerns.  
-- Once endorsed, the OBIS Secretariat harvests the dataset directly from the source IPT and lists it on the endorsing node’s OBIS page.  
+To close this gap, the OBIS Secretariat developed a Python package that uses the GBIF API to detect "missing" datasets and create GitHub issues for nodes to review.
 
-This process ensures that:  
-- The **same, best-quality “master copy”** of each dataset flows to both GBIF and OBIS.  
-- **Duplicate records are avoided**.  
-- OBIS is **recognized within GBIF as the global marine biodiversity network**.  
+## Workflow
 
-All OBIS node managers and data managers are encouraged to **watch this repository** and stay engaged in reviewing and endorsing new datasets.  
+- Each dataset appears here as an issue.
+- OBIS nodes are expected to:
+  - Monitor these issues.
+  - Endorse appropriate datasets.
+  - Coordinate with publishers to resolve any quality concerns.
+- Once endorsed, the OBIS Secretariat harvests the dataset directly from the source IPT and lists it on the endorsing node's OBIS page.
 
-## Assignments  
+This process ensures that:
+- The **same, best-quality "master copy"** of each dataset flows to both GBIF and OBIS.
+- **Duplicate records are avoided**.
+- OBIS is **recognized within GBIF as the global marine biodiversity network**.
 
-GitHub accounts per OBIS node used to assign datasets:  
+All OBIS node managers and data managers are encouraged to **watch this repository** and stay engaged in reviewing and endorsing new datasets.
 
-- AntOBIS: @ymgan  
-- IndOBIS: @johnny3125  
-- Caribbean OBIS: @diodon, @cperaltab  
-- OBIS Japan: @hosonot  
-- EurOBIS: @cyrilrader  
-- OBIS Australia: @obisau  
-- OBIS Deepsea: @haniehsaeedi  
-- AfrOBIS: @TRasehlomi  
-- OBIS China: @ZhaocuiMeng  
-- OBIS Canada: @cornthwaitem  
-- OBIS Ecuador: @vechocho, @gbif-ec  
-- OBIS UK: @dblear  
-- Ocean Tracking Network: @jdpye
+## Assignments
+
+GitHub accounts per OBIS node used to assign datasets:
+
+- AntOBIS: @ymgan
+- IndOBIS: @johnny3125
+- Caribbean OBIS: @diodon, @cperaltab
+- OBIS Japan: @hosonot
+- EurOBIS: @cyrilrader
+- OBIS Australia: @obisau
+- OBIS Deepsea: @haniehsaeedi
+- AfrOBIS: @TRasehlomi
+- OBIS China: @ZhaocuiMeng
 - OBIS Canada: @cornthwaitem
+- OBIS Ecuador: @vechocho, @gbif-ec
+- OBIS UK: @dblear
+- Ocean Tracking Network: @jdpye
 - OBIS Brazil: @ClaraBaringoFonseca
 
-To view all open issues **not currently assigned to a node**, use [this filter](https://github.com/iobis/obis-network-datasets/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20label%3Adataset%20-label%3A%22node%3A%20OBIS%20China%22%20-label%3A%22node%3A%20OBIS%20SEAMAP%22%20-label%3A%22node%3A%20OBIS%20Colombia%22%20-label%3A%22node%3A%20OBIS%20Malaysia%22%20-label%3A%22node%3A%20OBIS%20Deep%20Sea%22%20-label%3A%22node%3A%20OBIS%20Brazil%22%20-label%3A%22node%3A%20OBIS%20Argentina%22%20-label%3A%22node%3A%20OBIS%20Australia%22%20-label%3A%22node%3A%20ESP%20OBIS%22%20-label%3A%22node%3A%20OBIS%20Black%20Sea%22%20-label%3A%22node%3A%20Caribbean%20OBIS%22%20-label%3A%22node%3A%20AfroOBIS%22%20-label%3A%22node%3A%20EurOBIS%22%20-label%3A%22node%3A%20OBIS%20CPPS%22%20-label%3A%22node%3A%20OBIS%20Ecuador%22%20-label%3A%22node%3A%20OBIS%20Norway%22%20-label%3A%22node%3A%20OBIS%20UK%22%20-label%3A%22node%3A%20OBIS%20USA%22%20-label%3A%22node%3A%20SWP%20OBIS%22%20-label%3A%22node%3A%20PEGO-OBIS%22%20-label%3A%22node%3A%20OBIS%20Canada%22).  
+To view all open issues **not currently assigned to a node**, use [this filter](https://github.com/iobis/obis-network-datasets/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20label%3Adataset%20-label%3A%22node%3A%20OBIS%20China%22%20-label%3A%22node%3A%20OBIS%20SEAMAP%22%20-label%3A%22node%3A%20OBIS%20Colombia%22%20-label%3A%22node%3A%20OBIS%20Malaysia%22%20-label%3A%22node%3A%20OBIS%20Deep%20Sea%22%20-label%3A%22node%3A%20OBIS%20Brazil%22%20-label%3A%22node%3A%20OBIS%20Argentina%22%20-label%3A%22node%3A%20OBIS%20Australia%22%20-label%3A%22node%3A%20ESP%20OBIS%22%20-label%3A%22node%3A%20OBIS%20Black%20Sea%22%20-label%3A%22node%3A%20Caribbean%20OBIS%22%20-label%3A%22node%3A%20AfroOBIS%22%20-label%3A%22node%3A%20EurOBIS%22%20-label%3A%22node%3A%20OBIS%20CPPS%22%20-label%3A%22node%3A%20OBIS%20Ecuador%22%20-label%3A%22node%3A%20OBIS%20Norway%22%20-label%3A%22node%3A%20OBIS%20UK%22%20-label%3A%22node%3A%20OBIS%20USA%22%20-label%3A%22node%3A%20SWP%20OBIS%22%20-label%3A%22node%3A%20PEGO-OBIS%22%20-label%3A%22node%3A%20OBIS%20Canada%22).
 
-## Automated checking for publication
+## Issue checker
 
-To help keep the repo up-to-date, a GitHub Action that runs weekly to check if datasets in open issues already exist in OBIS.
+A GitHub Action that runs weekly to check whether datasets in open issues already exist in OBIS.
 
 **What it does:**
 - Scans open issues for dataset titles and URLs
-- Queries the OBIS API for exact title matches
+- Queries the OBIS API for an exact title match
 - Compares source URLs between the issue and OBIS
+- If the issue's URLs don't match OBIS but the issue references a GBIF dataset, cross-checks the GBIF identifiers (DOI, DwC-A endpoint) against the OBIS source URLs
 
 **Results:**
 - **Exact match (title + URL)**: Adds "In OBIS" label, comments with OBIS link, and closes the issue
@@ -66,14 +70,32 @@ To help keep the repo up-to-date, a GitHub Action that runs weekly to check if d
 
 **Schedule:** Runs automatically every Sunday at midnight UTC, or can be triggered manually via the Actions tab.
 
-## Python Package  
+## Running the tools
 
-This repository also includes the Python package that creates issues for datasets linked to the OBIS network in the GBIF registry.  
+This repository ships as a Python package with two entry points: the **producer**, which creates new issues for GBIF datasets that aren't in OBIS, and the **issue checker**, which closes issues for datasets that have since been published to OBIS.
 
-### Run  
+### Setup
 
-1. Create a `.env` file with environment variables `GITHUB_USER` and `GITHUB_ACCESS_TOKEN`.  
-2. Run:  
+Create a `.env` file with environment variables `GITHUB_USER` and `GITHUB_ACCESS_TOKEN`. Install the package:
 
-   ```bash
-   python -m obisnd
+```bash
+pip install -e .
+```
+
+### Producer
+
+Creates new issues for GBIF-tagged OBIS-network datasets that aren't yet in OBIS:
+
+```bash
+python -m obisnd
+```
+
+### Issue checker
+
+Walks open issues and closes any that are now in OBIS. Supports `--dry-run` to log intended actions without making changes:
+
+```bash
+python -m obisnd.issue_checker --dry-run
+```
+
+Other options: `--issue-range START END`, `--issues N N N`, `--repo owner/name`. The issue checker uses the `GITHUB_TOKEN` environment variable (separate from the producer's `GITHUB_ACCESS_TOKEN`). When run as a GitHub Action, both are provided automatically.

--- a/check_one.py
+++ b/check_one.py
@@ -1,0 +1,84 @@
+"""
+Local dry-run check for a single GBIF dataset.
+
+Usage:
+    python check_one.py 3f8c5321-4081-46fc-84ef-27c12735c3a5
+
+Fetches the dataset from GBIF, runs the same identifier-building and
+OBIS/GitHub-dedup logic that ObisNetworkDatasets.run() uses, and prints
+what the resulting GitHub issue body would look like. Does NOT post to
+GitHub.
+"""
+
+import sys
+import requests
+import yaml
+
+from obisnd import ObisNetworkDatasets
+from obisnd.gbif import create_gbif_url
+
+
+def fetch_one_gbif_dataset(dataset_uuid):
+    url = f"https://api.gbif.org/v1/dataset/{dataset_uuid}"
+    res = requests.get(url, headers={"User-Agent": "iobis/obis-network-datasets"})
+    res.raise_for_status()
+    return res.json()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python check_one.py <dataset_uuid> [--show-body]")
+        sys.exit(1)
+
+    dataset_uuid = sys.argv[1]
+
+    print(f"Fetching GBIF dataset {dataset_uuid} ...")
+    gbif_dataset = fetch_one_gbif_dataset(dataset_uuid)
+
+    print("Loading OBIS datasets, blacklist, and existing GitHub issues (this takes a minute) ...")
+    ond = ObisNetworkDatasets()
+
+    # Replicate the identifier-building logic from run() exactly.
+    identifiers = [i["identifier"] for i in gbif_dataset["identifiers"]]
+    if gbif_dataset.get("doi") is not None:
+        doi_url = ond.normalize_identifier(gbif_dataset["doi"])
+        if doi_url not in identifiers:
+            identifiers.append(doi_url)
+    for endpoint in gbif_dataset.get("endpoints", []):
+        if endpoint.get("type") == "DWC_ARCHIVE" and endpoint.get("url") is not None:
+            if endpoint["url"] not in identifiers:
+                identifiers.append(endpoint["url"])
+
+    print("\n=== Identifiers that would be checked / written ===")
+    for i in identifiers:
+        print(f"  - {i}")
+
+    has_dwc = ond.dataset_has_dwc_endpoint(gbif_dataset)
+    is_orphaned = ond.dataset_is_orphaned(gbif_dataset)
+    in_obis = ond.obis_has_dataset(identifiers)
+    in_github = ond.github_has_issue(identifiers)
+
+    print("\n=== Checks ===")
+    print(f"  Has DwC-A endpoint:    {has_dwc}")
+    print(f"  Is orphaned:           {is_orphaned}")
+    print(f"  Already in OBIS:       {in_obis}")
+    print(f"  Already has GH issue:  {in_github}")
+
+    would_create = has_dwc and not in_obis and not is_orphaned and not in_github
+
+    print(f"\n=== Decision ===")
+    print(f"  Would create new issue: {would_create}")
+
+    if would_create or "--show-body" in sys.argv:
+        props = [
+            {"title": gbif_dataset["title"]},
+            {"GBIF": create_gbif_url(gbif_dataset["key"])},
+            {"created": gbif_dataset["created"]},
+            {"URLs": identifiers},
+        ]
+        print("\n=== Issue body that would be posted ===")
+        print(yaml.dump(props))
+
+
+if __name__ == "__main__":
+    main()

--- a/check_one.py
+++ b/check_one.py
@@ -3,6 +3,7 @@ Local dry-run check for a single GBIF dataset.
 
 Usage:
     python check_one.py 3f8c5321-4081-46fc-84ef-27c12735c3a5
+    python check_one.py 3f8c5321-4081-46fc-84ef-27c12735c3a5 --show-body
 
 Fetches the dataset from GBIF, runs the same identifier-building and
 OBIS/GitHub-dedup logic that ObisNetworkDatasets.run() uses, and prints
@@ -15,7 +16,7 @@ import requests
 import yaml
 
 from obisnd import ObisNetworkDatasets
-from obisnd.gbif import create_gbif_url
+from obisnd.gbif import create_gbif_url, collect_identifiers
 
 
 def fetch_one_gbif_dataset(dataset_uuid):
@@ -38,16 +39,7 @@ def main():
     print("Loading OBIS datasets, blacklist, and existing GitHub issues (this takes a minute) ...")
     ond = ObisNetworkDatasets()
 
-    # Replicate the identifier-building logic from run() exactly.
-    identifiers = [i["identifier"] for i in gbif_dataset["identifiers"]]
-    if gbif_dataset.get("doi") is not None:
-        doi_url = ond.normalize_identifier(gbif_dataset["doi"])
-        if doi_url not in identifiers:
-            identifiers.append(doi_url)
-    for endpoint in gbif_dataset.get("endpoints", []):
-        if endpoint.get("type") == "DWC_ARCHIVE" and endpoint.get("url") is not None:
-            if endpoint["url"] not in identifiers:
-                identifiers.append(endpoint["url"])
+    identifiers = collect_identifiers(gbif_dataset)
 
     print("\n=== Identifiers that would be checked / written ===")
     for i in identifiers:

--- a/obisnd/__init__.py
+++ b/obisnd/__init__.py
@@ -1,7 +1,8 @@
 import logging
-from obisnd.gbif import get_obis_network_datasets, create_gbif_url
-from obisnd.obis import get_obis_datasets, get_obis_blacklist
+from obisnd.gbif import get_obis_network_datasets, create_gbif_url, collect_identifiers
+from obisnd.obis import get_obis_datasets, get_obis_blacklist, collect_urls
 from obisnd.github import get_github_issues, create_github_issue
+from obisnd.utils import urls_match
 from termcolor import colored
 
 
@@ -17,54 +18,46 @@ class ObisNetworkDatasets:
         self.github_issues = get_github_issues()
         self.gbif_datasets = get_obis_network_datasets()
 
-        # Collect both the resource page URL ("url") and the DwC-A archive
-        # URL ("archive") from OBIS, so dedup works against either form.
-        obis_urls = []
+        # Flatten every OBIS dataset's source URLs into one comparison list.
+        # collect_urls() pulls both the resource page URL and the DwC-A
+        # archive URL, normalized, so dedup works against either form.
+        self.obis_datasets = []
         for dataset in obis_datasets:
-            if dataset.get("url") is not None:
-                obis_urls.append(dataset["url"].replace("https://", "http://"))
-            if dataset.get("archive") is not None:
-                obis_urls.append(dataset["archive"].replace("https://", "http://"))
-        self.obis_datasets = obis_urls
+            self.obis_datasets.extend(collect_urls(dataset))
 
-        self.obis_blacklist = [dataset["url"].replace("https://", "http://") for dataset in get_obis_blacklist() if dataset["url"] is not None]
+        self.obis_blacklist = []
+        for dataset in get_obis_blacklist():
+            self.obis_blacklist.extend(collect_urls(dataset))
+
         self.obis_titles = [dataset["title"] for dataset in obis_datasets if dataset["title"] is not None]
 
     def obis_has_dataset(self, identifiers, title=None):
-        for identifier in identifiers:
-            if identifier.replace("https://", "http://") in self.obis_datasets:
-                return True
-            if identifier.replace("https://", "http://") in self.obis_blacklist:
-                return True
-            if title is not None and title in self.obis_titles:
-                return True
+        if urls_match(identifiers, self.obis_datasets):
+            return True
+        if urls_match(identifiers, self.obis_blacklist):
+            return True
+        if title is not None and title in self.obis_titles:
+            return True
         return False
 
-    def normalize_identifier(self, identifier):
-        identifier = identifier.replace("https://", "http://")
-        if identifier.endswith("/"):
-            identifier = identifier[:-1]
-        if identifier.startswith("10."):
-            identifier = identifier.replace("10.", "https://doi.org/10.")
-        return identifier
-
     def github_has_issue(self, identifiers):
-        for identifier in identifiers:
-            for issue in self.github_issues:
-                if issue["body"] is not None and "URLs" in issue["body"]:
-                    for url in issue["body"]["URLs"]:
-                        if self.normalize_identifier(identifier) == self.normalize_identifier(url):
-                            return True
+        for issue in self.github_issues:
+            if issue["body"] is None or "URLs" not in issue["body"]:
+                continue
+            if urls_match(identifiers, issue["body"]["URLs"]):
+                return True
         return False
 
     def dataset_is_orphaned(self, gbif_dataset):
-        if len([endpoint["url"] for endpoint in gbif_dataset["endpoints"] if endpoint["url"].startswith("https://orphans.gbif.org")]) > 0:
-            return True
+        for endpoint in gbif_dataset["endpoints"]:
+            if endpoint["url"].startswith("https://orphans.gbif.org"):
+                return True
         return False
 
     def dataset_has_dwc_endpoint(self, gbif_dataset):
-        if len([endpoint["url"] for endpoint in gbif_dataset["endpoints"] if endpoint["type"] == "DWC_ARCHIVE"]) > 0:
-            return True
+        for endpoint in gbif_dataset["endpoints"]:
+            if endpoint["type"] == "DWC_ARCHIVE":
+                return True
         return False
 
     def run(self, dry_run=False):
@@ -73,33 +66,29 @@ class ObisNetworkDatasets:
 
         for gbif_dataset in self.gbif_datasets:
             gbif_url = create_gbif_url(gbif_dataset["key"])
-
-            identifiers = [identifier["identifier"] for identifier in gbif_dataset["identifiers"]]
-            if gbif_dataset["doi"] is not None:
-                doi_url = self.normalize_identifier(gbif_dataset["doi"])
-                if doi_url not in identifiers:
-                    identifiers.append(doi_url)
-
-            # Add DwC-A archive endpoint URL(s) from GBIF. GBIF no longer
-            # auto-populates these into the dataset's "identifiers" array,
-            # so pull them directly from "endpoints".
-            for endpoint in gbif_dataset["endpoints"]:
-                if endpoint.get("type") == "DWC_ARCHIVE" and endpoint.get("url") is not None:
-                    if endpoint["url"] not in identifiers:
-                        identifiers.append(endpoint["url"])
+            identifiers = collect_identifiers(gbif_dataset)
 
             if not self.dataset_has_dwc_endpoint(gbif_dataset):
                 logger.info(colored(f"No IPT URL found for {gbif_url}", "red"))
-            else:
-                if not self.obis_has_dataset(identifiers):
-                    logger.info(colored(f"Dataset not in OBIS: {gbif_url}", "blue"))
-                    if not self.dataset_is_orphaned(gbif_dataset):
-                        logger.info(colored(f"Dataset is not orphaned: {gbif_url}", "blue"))
-                        if not self.github_has_issue(identifiers):
-                            logger.info(colored(f"Dataset not in GitHub: {gbif_url}", "green"))
-                            count_new = count_new + 1
+                continue
 
-                            if not dry_run:
-                                create_github_issue(gbif_dataset, identifiers)
+            if self.obis_has_dataset(identifiers):
+                continue
+
+            logger.info(colored(f"Dataset not in OBIS: {gbif_url}", "blue"))
+
+            if self.dataset_is_orphaned(gbif_dataset):
+                continue
+
+            logger.info(colored(f"Dataset is not orphaned: {gbif_url}", "blue"))
+
+            if self.github_has_issue(identifiers):
+                continue
+
+            logger.info(colored(f"Dataset not in GitHub: {gbif_url}", "green"))
+            count_new += 1
+
+            if not dry_run:
+                create_github_issue(gbif_dataset, identifiers)
 
         logger.info(colored(f"New datasets: {count_new}", "green"))

--- a/obisnd/gbif.py
+++ b/obisnd/gbif.py
@@ -1,6 +1,9 @@
 import requests
 import logging
 
+from obisnd.utils import normalize_url
+
+
 logger = logging.getLogger(__name__)
 session = requests.Session()
 session.headers.update({"User-Agent": "iobis/obis-network-datasets"})
@@ -30,3 +33,58 @@ def get_obis_network_datasets():
 
 def create_gbif_url(dataset_id):
     return f"https://www.gbif.org/dataset/{dataset_id}"
+
+
+def collect_identifiers(gbif_dataset):
+    """Build the list of identifiers that uniquely point to one GBIF dataset.
+
+    Combines three sources from a GBIF dataset record:
+
+    1. The ``identifiers`` array (URLs, DOIs, LSIDs, etc. that GBIF tracks).
+    2. The ``doi`` field, if present and not already covered by (1). A
+       bare DOI starting with ``10.`` is rewritten as ``https://doi.org/...``.
+    3. The URL of every ``DWC_ARCHIVE`` endpoint in the ``endpoints``
+       array. This is the archive download URL OBIS would harvest from.
+       GBIF stopped auto-populating these into ``identifiers`` for newer
+       datasets, so reading from ``endpoints`` is required for reliable
+       matching.
+
+    Each URL is normalized via :func:`obisnd.utils.normalize_url`.
+    Duplicates are removed while preserving order of first appearance.
+
+    Args:
+        gbif_dataset: A single dataset record from the GBIF API,
+            typically from ``/v1/dataset/{key}`` or
+            ``/v1/network/{key}/constituents``.
+
+    Returns:
+        A deduplicated, normalized list of identifier strings.
+    """
+    identifiers = []
+
+    for entry in gbif_dataset.get("identifiers") or []:
+        value = entry.get("identifier")
+        if isinstance(value, str) and value:
+            identifiers.append(normalize_url(value))
+
+    doi = gbif_dataset.get("doi")
+    if isinstance(doi, str) and doi:
+        if doi.startswith("10."):
+            doi_url = normalize_url(f"https://doi.org/{doi}")
+        else:
+            doi_url = normalize_url(doi)
+        identifiers.append(doi_url)
+
+    for endpoint in gbif_dataset.get("endpoints") or []:
+        if endpoint.get("type") == "DWC_ARCHIVE":
+            value = endpoint.get("url")
+            if isinstance(value, str) and value:
+                identifiers.append(normalize_url(value))
+
+    seen = set()
+    deduped = []
+    for ident in identifiers:
+        if ident not in seen:
+            seen.add(ident)
+            deduped.append(ident)
+    return deduped

--- a/obisnd/issue_checker.py
+++ b/obisnd/issue_checker.py
@@ -2,15 +2,22 @@
 """
 Check open GitHub issues against the OBIS database and label/close matches.
 
-This script iterates over open issues in a GitHub repository (default:
-iobis/obis-network-datasets), searches the OBIS API for each issue's title,
-and takes action based on the result:
+This module is the counterpart to the issue producer in
+:mod:`obisnd`. The producer files new issues for GBIF datasets that
+look like they should be in OBIS but aren't yet. Over time, OBIS nodes
+endorse those datasets and OBIS harvests them, but the corresponding
+issues stay open until something notices. This module is that something.
 
-  - Full match (title AND a source URL match): adds a comment pointing to
-    the OBIS dataset, applies the "In OBIS" label, and closes the issue.
-  - Title-only match (URLs do not match): adds a warning comment listing
-    both sets of URLs, but leaves the issue open and unlabeled.
-  - No title match: logs the result and moves on.
+For each open issue, the script:
+
+  - Searches OBIS for a dataset with the same title.
+  - If a title match is found, compares URLs to confirm same source:
+    full match (title + URL) → comment, label "In OBIS", and close.
+    title match only         → warning comment, leave issue open.
+  - If the issue's URLs don't match OBIS but the issue references a
+    GBIF UUID, falls back to checking the GBIF DwC-A endpoint against
+    OBIS. This catches older issues that were filed before the DwC-A
+    URL was written into the issue body.
 
 Environment variables:
     GITHUB_TOKEN  (required) GitHub personal access token with repo scope.
@@ -19,19 +26,16 @@ Usage:
     export GITHUB_TOKEN=ghp_xxx
 
     # Live run against the default repo
-    python check_title_against_obis.py
+    python -m obisnd.issue_checker
 
     # Safe test run that logs intended actions but makes no changes
-    python check_title_against_obis.py --dry-run
+    python -m obisnd.issue_checker --dry-run
 
     # Restrict to a specific issue-number range (inclusive)
-    python check_title_against_obis.py --issue-range 100 150
+    python -m obisnd.issue_checker --issue-range 100 150
 
     # Run against a different repository
-    python check_title_against_obis.py --repo someorg/somerepo
-
-Dependencies:
-    pip install requests PyGithub
+    python -m obisnd.issue_checker --repo someorg/somerepo
 """
 
 import argparse
@@ -44,17 +48,21 @@ import traceback
 import requests
 from github import Auth, Github
 
+from obisnd.gbif import collect_identifiers
+from obisnd.obis import collect_urls
+from obisnd.utils import urls_match
+
+
+# UUID pattern used by both URL extraction and GBIF UUID extraction.
+UUID_PATTERN = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
 
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 
 def parse_args():
-    """Parse command-line arguments.
-
-    Returns:
-        argparse.Namespace with attributes: repo, dry_run, issue_range, sleep.
-    """
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
         description=(
             "Check open GitHub issues against the OBIS database and "
@@ -105,82 +113,40 @@ def parse_args():
 
 
 # ---------------------------------------------------------------------------
-# URL extraction and matching
+# Issue-body parsing
 # ---------------------------------------------------------------------------
 
-def extract_urls_from_issue(issue_body):
-    """Extract all URLs (and GBIF dataset URLs from bare UUIDs) from an issue body.
+def extract_urls_from_body(issue_body):
+    """Extract URLs and GBIF dataset URLs from an issue body.
+
+    Finds all bare URLs in the text, plus any UUIDs that may be GBIF
+    dataset IDs (returned as constructed gbif.org URLs).
 
     Args:
-        issue_body: The raw text of a GitHub issue body. May be None or empty.
+        issue_body: Raw text of a GitHub issue body. May be None or empty.
 
     Returns:
-        A deduplicated list of URL strings. Any UUIDs found in the body are
-        also returned as constructed GBIF dataset URLs of the form
-        'https://www.gbif.org/dataset/<uuid>'.
+        A deduplicated list of URL strings.
     """
     if not issue_body:
         return []
 
-    # Find all URLs in the issue body
     url_pattern = r'https?://[^\s<>"\')]+|www\.[^\s<>"\')]+'
     urls = re.findall(url_pattern, issue_body)
 
-    # Also extract UUIDs that might be GBIF dataset IDs
     uuids = re.findall(UUID_PATTERN, issue_body, re.IGNORECASE)
-
-    # Add GBIF dataset URLs for found UUIDs
     for uuid in uuids:
         urls.append(f"https://www.gbif.org/dataset/{uuid}")
 
     return list(set(urls))
 
 
-def check_url_match_simple(issue_urls, obis_urls):
-    """Check whether any issue URL matches any OBIS URL (ignoring http vs https).
+def extract_gbif_uuid_from_body(issue_body):
+    """Extract a GBIF dataset UUID from an issue body, if present.
 
-    Args:
-        issue_urls: List of URLs extracted from the GitHub issue.
-        obis_urls: List of URLs reported by OBIS for the candidate dataset.
-
-    Returns:
-        True if at least one normalized issue URL appears in the normalized
-        OBIS URL list; False otherwise.
-    """
-    if not obis_urls:
-        return False
-
-    def normalize_url(url):
-        url = url.strip()
-        if url.startswith('https://'):
-            url = url.replace('https://', 'http://', 1)
-        return url
-
-    normalized_issue_urls = [normalize_url(u) for u in issue_urls]
-    normalized_obis_urls = [normalize_url(u) for u in obis_urls]
-
-    for issue_url in normalized_issue_urls:
-        if issue_url in normalized_obis_urls:
-            return True
-
-    return False
-
-
-# ---------------------------------------------------------------------------
-# GBIF lookup
-# ---------------------------------------------------------------------------
-
-# Reused by both URL extraction and GBIF UUID extraction.
-UUID_PATTERN = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
-
-
-def extract_gbif_uuid(issue_body):
-    """Extract the GBIF dataset UUID from an issue body, if one is present.
-
-    Looks for the first UUID associated with a gbif.org URL. If no
-    gbif-qualified UUID is found, falls back to the first bare UUID in
-    the body (issues created by the GitHub Actions bot include a 'GBIF:'
-    line whose UUID is the only one present).
+    Prefers a UUID that appears inside a gbif.org URL. Falls back to the
+    first bare UUID in the body (issues filed by the producer include a
+    'GBIF:' line whose UUID is the only one present).
 
     Args:
         issue_body: Raw text of a GitHub issue body. May be None or empty.
@@ -191,7 +157,6 @@ def extract_gbif_uuid(issue_body):
     if not issue_body:
         return None
 
-    # Prefer a UUID that appears in a gbif.org URL.
     gbif_url_match = re.search(
         r'gbif\.org/dataset/(' + UUID_PATTERN + r')',
         issue_body,
@@ -200,7 +165,6 @@ def extract_gbif_uuid(issue_body):
     if gbif_url_match:
         return gbif_url_match.group(1).lower()
 
-    # Fall back to the first bare UUID in the body.
     bare = re.search(UUID_PATTERN, issue_body, re.IGNORECASE)
     if bare:
         return bare.group(0).lower()
@@ -208,20 +172,30 @@ def extract_gbif_uuid(issue_body):
     return None
 
 
-def get_gbif_dwc_archive_urls(gbif_uuid):
-    """Fetch DWC_ARCHIVE endpoint URLs for a GBIF dataset.
+# ---------------------------------------------------------------------------
+# GBIF fallback lookup
+# ---------------------------------------------------------------------------
+
+def fetch_gbif_identifiers(gbif_uuid):
+    """Fetch identifiers for one GBIF dataset, for the cross-check fallback.
+
+    Used when an issue's own URLs don't match OBIS but the issue
+    references a GBIF dataset. Returns the same identifier list that
+    :func:`obisnd.gbif.collect_identifiers` produces, along with a status
+    string so the caller can distinguish "no DwC-A endpoint registered"
+    from "couldn't reach GBIF" in its logging.
 
     Args:
         gbif_uuid: GBIF dataset UUID (string).
 
     Returns:
-        A 2-tuple (urls, status):
-            urls (list[str]): DWC_ARCHIVE endpoint URLs from the GBIF
-                dataset record. Empty list if none are registered.
-            status (str): One of 'ok', 'no_dwc_archive', 'not_found', 'error'.
-                Provided so the caller can distinguish "GBIF says this
-                dataset has no DWC_ARCHIVE endpoint" (a genuine data gap)
-                from "we couldn't reach GBIF" (a transient failure).
+        A 2-tuple ``(identifiers, status)``:
+            identifiers (list[str]): Normalized identifier URLs from the
+                GBIF record (DOI, ``identifiers`` array, DwC-A endpoints).
+            status (str): One of 'ok', 'no_dwc_archive', 'not_found',
+                'error'. 'no_dwc_archive' specifically means GBIF returned
+                a dataset record but no DWC_ARCHIVE endpoint was registered
+                on it.
     """
     if not gbif_uuid:
         return [], 'error'
@@ -234,16 +208,15 @@ def get_gbif_dwc_archive_urls(gbif_uuid):
         response.raise_for_status()
         data = response.json()
 
-        endpoints = data.get('endpoints') or []
-        dwc_urls = [
-            ep.get('url')
-            for ep in endpoints
-            if ep.get('type') == 'DWC_ARCHIVE' and ep.get('url')
-        ]
+        identifiers = collect_identifiers(data)
 
-        if not dwc_urls:
-            return [], 'no_dwc_archive'
-        return dwc_urls, 'ok'
+        has_dwc_archive = any(
+            ep.get('type') == 'DWC_ARCHIVE' and ep.get('url')
+            for ep in (data.get('endpoints') or [])
+        )
+        if not has_dwc_archive:
+            return identifiers, 'no_dwc_archive'
+        return identifiers, 'ok'
 
     except Exception as e:
         print(f"  Error fetching GBIF dataset {gbif_uuid}: {e}")
@@ -254,8 +227,8 @@ def get_gbif_dwc_archive_urls(gbif_uuid):
 # OBIS lookup
 # ---------------------------------------------------------------------------
 
-def search_obis_dataset(dataset_title, issue_urls):
-    """Search OBIS for a dataset by exact title match and verify its URLs.
+def find_obis_match(dataset_title, issue_urls):
+    """Search OBIS for a dataset by exact title and verify its URLs.
 
     Performs a case-insensitive exact title match against the OBIS
     /dataset/search2 endpoint, then compares the matched dataset's source
@@ -268,14 +241,13 @@ def search_obis_dataset(dataset_title, issue_urls):
             used to verify that the OBIS hit refers to the same source.
 
     Returns:
-        A 4-tuple (title_match, url_match, dataset_url, obis_urls):
-            title_match (bool or None): True if an exact title match was
-                found in OBIS, False if no match, None on error.
+        A 4-tuple ``(title_match, url_match, dataset_url, obis_urls)``:
+            title_match (bool or None): True if exact title match found,
+                False if no match, None on error.
             url_match (bool): True if any issue URL matches an OBIS URL.
             dataset_url (str or None): obis.org URL for the matched dataset.
             obis_urls (list[str]): Source URLs reported by OBIS for the
-                matched dataset (drawn from 'url' and 'archive' fields of
-                the search result).
+                matched dataset (from :func:`obisnd.obis.collect_urls`).
     """
     if not dataset_title or not isinstance(dataset_title, str):
         print(f"  ERROR: Invalid dataset_title: {type(dataset_title)}")
@@ -295,19 +267,12 @@ def search_obis_dataset(dataset_title, issue_urls):
                 if not result_title or not isinstance(result_title, str):
                     continue
 
-                # Case-insensitive exact title match
                 if result_title.strip().lower() == dataset_title.strip().lower():
                     dataset_id = result.get('id')
                     if dataset_id:
                         dataset_url = f"https://obis.org/dataset/{dataset_id}"
-
-                        obis_urls = []
-                        for field in ('url', 'archive'):
-                            value = result.get(field)
-                            if value and isinstance(value, str):
-                                obis_urls.append(value)
-
-                        url_match = check_url_match_simple(issue_urls, obis_urls)
+                        obis_urls = collect_urls(result)
+                        url_match = urls_match(issue_urls, obis_urls)
                         return True, url_match, dataset_url, obis_urls
 
         return False, False, None, []
@@ -319,17 +284,11 @@ def search_obis_dataset(dataset_title, issue_urls):
 
 
 # ---------------------------------------------------------------------------
-# Per-issue handling
+# Per-issue actions
 # ---------------------------------------------------------------------------
 
-def handle_full_match(issue, dataset_url, dry_run):
-    """Comment, label, and close an issue that fully matches an OBIS dataset.
-
-    Args:
-        issue: A PyGithub Issue object.
-        dataset_url: The obis.org URL pointing to the matched dataset.
-        dry_run: If True, log intended actions without modifying GitHub.
-    """
+def close_on_full_match(issue, dataset_url, dry_run):
+    """Comment, label, and close an issue that fully matches an OBIS dataset."""
     if dry_run:
         print(f"\n[DRY RUN] Would add comment:")
         print(f"  'Dataset is published to OBIS: {dataset_url}'")
@@ -355,16 +314,8 @@ def handle_full_match(issue, dataset_url, dry_run):
     print(f"✓ Closed issue")
 
 
-def handle_title_only_match(issue, dataset_url, issue_urls, obis_urls, dry_run):
-    """Add a warning comment to an issue whose title matches but URLs do not.
-
-    Args:
-        issue: A PyGithub Issue object.
-        dataset_url: The obis.org URL of the title-matched OBIS dataset.
-        issue_urls: List of URLs extracted from the issue body.
-        obis_urls: List of source URLs reported by OBIS for the dataset.
-        dry_run: If True, log intended actions without modifying GitHub.
-    """
+def comment_on_title_only_match(issue, dataset_url, issue_urls, obis_urls, dry_run):
+    """Add a warning comment when title matches OBIS but URLs do not."""
     if dry_run:
         print(f"\n[DRY RUN] Would add comment about title match but no URL match")
         print(f"[DRY RUN] Would NOT add 'In OBIS' label")
@@ -402,7 +353,6 @@ def main():
     """Entry point: parse args, fetch issues, and process each one."""
     args = parse_args()
 
-    # Allow DRY_RUN env var as a fallback for backwards compatibility.
     dry_run = args.dry_run or os.environ.get('DRY_RUN', 'false').lower() == 'true'
 
     if dry_run:
@@ -419,7 +369,6 @@ def main():
     g = Github(auth=auth)
     repo = g.get_repo(args.repo)
 
-    # Ensure the label exists (only if not dry run)
     if not dry_run:
         try:
             repo.get_label("In OBIS")
@@ -456,8 +405,8 @@ def main():
     print(f"Found {len(open_issues)} open issues (excluding PRs)\n")
 
     checked_count = 0
-    full_match_issues = []        # issue numbers where title + URL matched
-    title_only_match_issues = []  # issue numbers where only the title matched
+    full_match_issues = []
+    title_only_match_issues = []
 
     for issue in open_issues:
         label_names = [label.name for label in issue.labels]
@@ -474,12 +423,12 @@ def main():
         print(f"Issue #{issue.number}: {dataset_title}")
         print(f"{'='*60}")
 
-        issue_urls = extract_urls_from_issue(issue.body)
+        issue_urls = extract_urls_from_body(issue.body)
         print(f"Found {len(issue_urls)} URLs in issue:")
         for u in issue_urls:
             print(f"  - {u}")
 
-        title_match, url_match, dataset_url, obis_urls = search_obis_dataset(
+        title_match, url_match, dataset_url, obis_urls = find_obis_match(
             dataset_title, issue_urls
         )
 
@@ -495,26 +444,26 @@ def main():
             if url_match:
                 full_match_issues.append(issue.number)
                 print(f"\n✓ FULL MATCH: Title and URL match!")
-                handle_full_match(issue, dataset_url, dry_run)
+                close_on_full_match(issue, dataset_url, dry_run)
             else:
                 # Title matches but the issue's URLs don't match OBIS.
                 # Cross-check via GBIF: if the issue references a GBIF
-                # dataset, the GBIF DWC_ARCHIVE endpoint URL is what OBIS
-                # actually harvests from, so it may match the OBIS URLs
-                # even when the issue body's URLs (e.g. a DOI) do not.
-                gbif_uuid = extract_gbif_uuid(issue.body)
+                # dataset, the GBIF DwC-A endpoint URL is what OBIS would
+                # have harvested from, so it may match OBIS even when
+                # the issue body's URLs (e.g. a DOI) do not.
+                gbif_uuid = extract_gbif_uuid_from_body(issue.body)
                 gbif_match = False
-                gbif_dwc_urls = []
+                gbif_identifiers = []
                 gbif_status = 'no_uuid'
 
                 if gbif_uuid:
-                    print(f"\nChecking GBIF DWC_ARCHIVE endpoint for {gbif_uuid}...")
-                    gbif_dwc_urls, gbif_status = get_gbif_dwc_archive_urls(gbif_uuid)
+                    print(f"\nChecking GBIF identifiers for {gbif_uuid}...")
+                    gbif_identifiers, gbif_status = fetch_gbif_identifiers(gbif_uuid)
                     if gbif_status == 'ok':
-                        print(f"GBIF DWC_ARCHIVE URLs ({len(gbif_dwc_urls)} total):")
-                        for u in gbif_dwc_urls:
+                        print(f"GBIF identifiers ({len(gbif_identifiers)} total):")
+                        for u in gbif_identifiers:
                             print(f"  - {u}")
-                        gbif_match = check_url_match_simple(gbif_dwc_urls, obis_urls)
+                        gbif_match = urls_match(gbif_identifiers, obis_urls)
                     elif gbif_status == 'no_dwc_archive':
                         print(f"  GAP: GBIF dataset has no DWC_ARCHIVE endpoint registered")
                     elif gbif_status == 'not_found':
@@ -526,12 +475,12 @@ def main():
 
                 if gbif_match:
                     full_match_issues.append(issue.number)
-                    print(f"\n✓ FULL MATCH (via GBIF): GBIF DWC_ARCHIVE URL matches OBIS source URL!")
-                    handle_full_match(issue, dataset_url, dry_run)
+                    print(f"\n✓ FULL MATCH (via GBIF): GBIF identifier matches OBIS source URL!")
+                    close_on_full_match(issue, dataset_url, dry_run)
                 else:
                     title_only_match_issues.append(issue.number)
                     print(f"\n⚠ PARTIAL MATCH: Title matches but URLs don't match (GBIF cross-check did not resolve)")
-                    handle_title_only_match(
+                    comment_on_title_only_match(
                         issue, dataset_url, issue_urls, obis_urls, dry_run
                     )
 

--- a/obisnd/obis.py
+++ b/obisnd/obis.py
@@ -1,6 +1,8 @@
 import requests
 import logging
 
+from obisnd.utils import normalize_url
+
 
 logger = logging.getLogger(__name__)
 session = requests.Session()
@@ -19,3 +21,29 @@ def get_obis_blacklist():
     res = session.get(url="https://api.obis.org/dataset/blacklist")
     datasets = res.json()["results"]
     return datasets
+
+
+def collect_urls(obis_dataset):
+    """Extract the source URLs OBIS reports for one dataset record.
+
+    Reads the ``url`` (IPT resource page) and ``archive`` (DwC-A endpoint)
+    fields. The ``feed`` field is deliberately not consulted: it is a
+    nested object holding the IPT-wide RSS feed URL, which is shared by
+    every dataset on the same IPT and therefore useless for per-dataset
+    identity matching.
+
+    Args:
+        obis_dataset: A single record from the OBIS dataset API, typically
+            an item from ``/dataset/search`` or ``/dataset/search2``.
+
+    Returns:
+        A list of URL strings, normalized via
+        :func:`obisnd.utils.normalize_url`. Empty if neither field is
+        populated.
+    """
+    urls = []
+    for field in ("url", "archive"):
+        value = obis_dataset.get(field)
+        if isinstance(value, str) and value:
+            urls.append(normalize_url(value))
+    return urls

--- a/obisnd/utils.py
+++ b/obisnd/utils.py
@@ -1,0 +1,60 @@
+"""
+Cross-cutting helpers that don't belong to any single external system.
+
+Anything that touches GBIF, OBIS, or GitHub specifically should live in
+the corresponding module (`gbif.py`, `obis.py`, `github.py`). This file
+is reserved for utilities used across multiple modules.
+"""
+
+from typing import Iterable
+
+
+def normalize_url(url: str) -> str:
+    """Normalize a URL for string-equality matching.
+
+    The only normalization applied is forcing the scheme to ``http://``.
+    Some IPTs were registered to GBIF/OBIS under ``http://`` and some
+    under ``https://``; collapsing both to one form prevents spurious
+    mismatches. No other transformations are applied (no trailing-slash
+    stripping, no case folding, no query-string changes).
+
+    Args:
+        url: A URL string. ``None`` and empty strings are returned unchanged.
+
+    Returns:
+        The URL with any leading ``https://`` replaced by ``http://``.
+    """
+    if not url:
+        return url
+    if url.startswith("https://"):
+        return "http://" + url[len("https://"):]
+    return url
+
+
+def urls_match(candidate_urls: Iterable, target_urls: Iterable) -> bool:
+    """Return True if any candidate URL appears in the target URL list.
+
+    Both inputs are normalized via :func:`normalize_url` before
+    comparison, so callers do not need to pre-normalize. Comparison is
+    exact string equality after normalization.
+
+    Args:
+        candidate_urls: URLs to look for (e.g. identifiers from a GBIF
+            dataset, or URLs extracted from an issue body).
+        target_urls: URLs to look in (e.g. all known OBIS source URLs,
+            or URLs from one OBIS dataset record).
+
+    Returns:
+        True if at least one normalized candidate appears in the
+        normalized target list. False if either input is empty or no
+        candidate matches.
+    """
+    targets = {normalize_url(u) for u in target_urls if u}
+    if not targets:
+        return False
+    for url in candidate_urls:
+        if not url:
+            continue
+        if normalize_url(url) in targets:
+            return True
+    return False

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,4 @@ install_requires =
     python-dotenv
     termcolor
     PyYAML
+    PyGithub


### PR DESCRIPTION
#### What changed:

- Issue creator (obisnd package): now adds the DwC-A archive endpoint
  to the URLs in newly-filed issues. GBIF stopped auto-populating these
  into dataset.identifiers, so they were silently dropping out of issue
  bodies and out of the OBIS-dedup check.
- Issue checker (formerly check_title_against_obis.py): moved into the
  package as obisnd.issue_checker. Now uses the same matching helpers
  as the issue creator instead of duplicating the logic.
- New shared module obisnd.utils for cross-cutting helpers
  (normalize_url, urls_match).
- New per-system helpers in gbif.py (collect_identifiers) and obis.py
  (collect_urls).
- Workflow renamed: check_title_against_obis.yml → issue_checker.yml.
  Installs the package via `pip install -e .` instead of pip-installing
  dependencies ad-hoc.
- setup.cfg: added PyGithub (was previously installed only by the old
  workflow).
- README: restructured, added overview video, renamed sections,
  dropped stale local-run instructions, corrected the env-var
  reference (GITHUB_TOKEN, not GITHUB_ACCESS_TOKEN).
- Removed dead code (the `feed` branch in OBIS URL collection, which
  was silently skipped because of a type-check mismatch).

Tested locally against the IMR fish dataset (issue #824) and Mar Piccolo (issue #158). Unfortunately, I can't seem to test in the branch before I merge.